### PR TITLE
Build and packaging-related fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+Contributor Guide
+=================
+
+Build
+-----
+
+> **Note**
+> 
+> This project uses source generators that are not included into the solution file. This may cause problems if you build the project in IDE.
+> 
+> If you experience any problems mentioning the `FixedMath.NET.Generators` assembly, run the following shell command before opening the project in the IDE:
+> 
+> ```console
+> $ dotnet build src/FixedMath.NET.Generators
+> ```
+> 
+> (alternately, open said project in the IDE and build it from there)
+
+Before building the project in the IDE, remember to build the source generators:
+
+To build the project, run this shell command:
+
+```
+$ dotnet build
+```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/OpenSAGE/FixedMath.NET/actions/workflows/ci.yml/badge.svg)](https://github.com/OpenSAGE/FixedMath.NET/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/OpenSAGE/FixedMath.NET/branch/master/graph/badge.svg?token=LZO8MJT5HA)](https://codecov.io/gh/OpenSAGE/FixedMath.NET)
-![Nuget](https://img.shields.io/nuget/v/fixedmath.net)
+[![Nuget](https://img.shields.io/nuget/v/fixedmath.net)](https://www.nuget.org/packages/FixedMath.NET)
 
 ## Changes
 

--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ In the unit tests you'll find implementations for Int32-based (Q15.16) and Byte-
 This project started as a port of libfixmath (http://code.google.com/p/libfixmath/).
 
 Note that the type requires explicit casts to convert to floating point and this is intentional, the difference between fixed point and floating point math is as important as the one between floating point and integral math.
+
+## Documentation
+
+- [Contributor Guide](CONTRIBUTING.md)

--- a/src/FixedMath.NET/FixedMath.NET.csproj
+++ b/src/FixedMath.NET/FixedMath.NET.csproj
@@ -2,8 +2,18 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+
+    <Description>This library implements "Fix64", a 64 bit fixed point 31.32 numeric type and transcendent operations on it (square root, trig, etc).</Description>
     <PackageLicenseExpression>Apache-2.0 AND MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/OpenSAGE/FixedMath.NET</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/OpenSAGE/FixedMath.NET.git</RepositoryUrl>
+    <PackageTags>math;fixed-point</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" Visible="false" />
+  </ItemGroup>
 
   <ItemGroup>
     <!-- Note that this is not a "normal" ProjectReference.

--- a/src/FixedMath.NET/FixedMath.NET.csproj
+++ b/src/FixedMath.NET/FixedMath.NET.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0 AND MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
1. I've noted that the generators project has to be built separately if you open the project in the IDE, so I've decided to add the contributor guide (named and placed according to the established practice).

   Note that it doesn't affect build from shell, only build from the IDE. Checked in both Visual Studio and Rider, and both are broken until you build the generators.

   Also note how nice does the `**Note**` block looks after GitHub renders it. It is a less known feature of GitHub Markdown renderer I've decided to use here :)

   <img width="721" alt="image" src="https://user-images.githubusercontent.com/92793/219975781-44b526ac-9ea4-4d2c-92d6-79bcec6222fd.png">


2. This isn't a big deal, but the project includes portions of code licensed under the MIT license, alongside the main Apache-2. That means that derived works should follow _both_ terms of MIT and Apache-2 simultaneously.

   NuGet supports special syntax of SPDX license expressions to express situations like this, so I've upgraded the package metadata accordingly.

   You can check that my expression is correct by following this link (it is included into the `.nuspec` generated by `dotnet pack` as well): https://licenses.nuget.org/Apache-2.0%20AND%20MIT

3. I've also added some minor pieces of NuGet metadata for the package to look nicer on nuget.org. We deserve better than the infamous "Package Description", do we? :)

   <img width="491" alt="image" src="https://user-images.githubusercontent.com/92793/219975878-93188a99-b176-4d49-9d0b-adde0ce60471.png">
